### PR TITLE
[ZUIX-590] Style 생성 시 className 맵핑 정보에 대한 버그를 일시적으로 막기 위함

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+registry "http://npm.zigbang.io/"
+always-auth true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2-zigbang.0",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/.npmrc
+++ b/packages/react-native-web/.npmrc
@@ -1,0 +1,2 @@
+registry=http://npm.zigbang.io/
+always-auth=true

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -1,10 +1,10 @@
 {
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
+		"registry": "https://npm.zigbang.io/"
+	},
   "name": "react-native-web",
-  "version": "0.17.1",
-  "description": "React Native for Web",
+  "version": "0.17.2-zigbang.0",
+  "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
   "sideEffects": false,
@@ -28,11 +28,11 @@
     "react": ">=17.0.1",
     "react-dom": ">=17.0.1"
   },
-  "author": "Nicolas Gallagher",
+  "author": "zigbang",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/necolas/react-native-web.git"
+    "url": "git://github.com/zigbang/react-native-web.git"
   },
   "tags": [
     "react"

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -163,10 +163,13 @@ export default function createStyleResolver() {
         (props, styleProp) => {
           const value = localizedStyle[styleProp];
           if (value != null) {
-            const className = getClassName(styleProp, value);
-            if (className) {
-              props.classList.push(className);
-            } else {
+            // https://github.com/necolas/react-native-web/issues/2007
+            // 위 사항에 대한 단기 해결방법을 위해 className 을 찾지 않도록 수정
+            //
+            // const className = getClassName(styleProp, value);
+            // if (className) {
+            //   props.classList.push(className);
+            // } else {
               // Certain properties and values are not transformed by 'createReactDOMStyle' as they
               // require more complex transforms into multiple CSS rules. Here we assume that StyleManager
               // can bind these styles to a className, and prevent them becoming invalid inline-styles.
@@ -191,7 +194,7 @@ export default function createStyleResolver() {
                 // 4x slower render
                 props.style[styleProp] = value;
               }
-            }
+            // }
           }
           return props;
         },


### PR DESCRIPTION
https://github.com/necolas/react-native-web/issues/2007

위 내용에 대한 이슈에 대한 style 들이 자동생성 되는 className 에 정상적으로 적용 안되는 버그를 일시적으로 막기 위한 처리방안입니다.