### PR TITLE
엘리먼트에서 classname 넘겨주게 하기 + classname을 없앰으로 인한 단점 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.0",
+  "version": "0.17.2-zigbang.1",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.1",
+  "version": "0.17.2-zigbang.2",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.0",
+  "version": "0.17.2-zigbang.1",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.1",
+  "version": "0.17.2-zigbang.2",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -118,7 +118,7 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
 
     let component = hasTextAncestor ? 'span' : 'div';
     const supportedProps = pickProps(props);
-    supportedProps.classList = classList;
+    supportedProps.classList = [].concat(props.className, classList);
     supportedProps.dir = dir;
     // 'auto' by default allows browsers to infer writing direction (root elements only)
     if (!hasTextAncestor) {

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -337,7 +337,7 @@ const TextInput: React.AbstractComponent<
   supportedProps.autoCapitalize = autoCapitalize;
   supportedProps.autoComplete = autoComplete || autoCompleteType || 'on';
   supportedProps.autoCorrect = autoCorrect ? 'on' : 'off';
-  supportedProps.classList = classList;
+  supportedProps.classList = [].concat(props.className, classList);
   // 'auto' by default allows browsers to infer writing direction
   supportedProps.dir = dir !== undefined ? dir : 'auto';
   supportedProps.enterKeyHint = returnKeyType;

--- a/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
+++ b/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
@@ -57,6 +57,7 @@ const forwardPropsList = {
   onBlur: true,
   onFocus: true,
   onLayout: true,
+  className: true,
   testID: true
 };
 

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -101,7 +101,7 @@ const View: React.AbstractComponent<ViewProps, HTMLElement & PlatformMethods> = 
     const style = StyleSheet.compose(hasTextAncestor && styles.inline, props.style);
 
     const supportedProps = pickProps(props);
-    supportedProps.classList = classList;
+    supportedProps.classList = [].concat(props.className, classList);
     supportedProps.style = style;
     if (props.href != null) {
       component = 'a';

--- a/packages/react-native-web/src/exports/View/types.js
+++ b/packages/react-native-web/src/exports/View/types.js
@@ -162,6 +162,7 @@ export type ViewProps = {
   onStartShouldSetResponderCapture?: (e: any) => boolean,
   pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto',
   style?: GenericStyleProp<ViewStyle>,
+  className?: ?string,
   testID?: ?string,
   // unstable
   dataSet?: ?Object,

--- a/packages/react-native-web/src/modules/forwardedProps/index.js
+++ b/packages/react-native-web/src/modules/forwardedProps/index.js
@@ -13,6 +13,7 @@ export const defaultProps = {
   nativeID: true,
   ref: true,
   suppressHydrationWarning: true,
+  className: true,
   testID: true
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8447,6 +8447,19 @@ react-jss@^10.5.1:
     theming "^3.3.0"
     tiny-warning "^1.0.2"
 
+react-native-web@0.17.1:
+  version "0.17.1"
+  resolved "http://npm.zigbang.io/react-native-web/-/react-native-web-0.17.1.tgz#90d473c89dd99b88bc9830b2a9fcdd2fc5f04902"
+  integrity sha512-lUnn+2O8ynQ6/gJKylSxm7DLi2vHw6AujdDV1+LSa8Epe1bYFJNUcJTEhJf0jNYUFGOujzMtuG8Mkz3HdWTkag==
+  dependencies:
+    array-find-index "^1.0.2"
+    create-react-class "^15.7.0"
+    fbjs "^3.0.0"
+    hyphenate-style-name "^1.0.4"
+    inline-style-prefixer "^6.0.0"
+    normalize-css-color "^1.0.2"
+    prop-types "^15.6.0"
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"


### PR DESCRIPTION
### 엘리먼트에서 classname 넘겨주게 하기
- 수정이유: https://www.notion.so/zigbang/react-native-web-935ed7f7eefd46379e8dc2a7a553a65e#41811fa8520a4da4a287c063e2bad5ec
### [classname을 없애서 문제를 해결한 PR](https://github.com/zigbang/react-native-web/pull/1) 을 리버트하고, 좀더 나은 방법으로 수정
- 문제점: (기본 스타일을 제외한) 모든 스타일이 전부 inline으로 생성되어서 퍼포먼스가 저하될 것으로 예상
  ![image](https://user-images.githubusercontent.com/14075436/126796383-9a6da497-4ed1-4433-8f83-fb904965aeec.png)
- classname으로 변환하기전, shorten style들을 전부 풀어서, 스타일이 오버라이딩 되지 않도록 처리 - https://github.com/zigbang/react-native-web/commit/cdd74ff7f40063f148c81d89ad05710a33f974cf
