### PR TITLE
Text line height를 상속받은 것으로 사용하도록 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.2",
+  "version": "0.17.2-zigbang.3",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.2",
+  "version": "0.17.2-zigbang.3",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -170,6 +170,7 @@ const classes = css.create({
     color: 'black',
     display: 'inline',
     font: '14px System',
+    lineHeight: 'inherit',
     margin: 0,
     padding: 0,
     whiteSpace: 'pre-wrap',

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -375,6 +375,7 @@ const classes = css.create({
     borderRadius: 0,
     boxSizing: 'border-box',
     font: '14px System',
+    lineHeight: 'inherit',
     margin: 0,
     padding: 0,
     resize: 'none'


### PR DESCRIPTION
## 이슈
- 최신 RNW에서는 text 컴포넌트에서 line-height를 초기화 하고 있어, 기존 앱에서 높이가 깨지는 현상이 발생
  ![image](https://user-images.githubusercontent.com/14075436/126947987-e13999c9-c90f-4c75-978f-bf68ea3f9c35.png)
- 높이를 상속받는 코드 추가하여 해결 
