### PR TITLE
모달 닫혔을때 클릭한 엘리먼트로 포커스 주는 기능 삭제

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.3",
+  "version": "0.17.2-zigbang.4",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.3",
+  "version": "0.17.2-zigbang.4",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -127,16 +127,16 @@ const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps): React.Node =
 
   // To be fully compliant with WCAG we need to refocus element that triggered opening modal
   // after closing it
-  React.useEffect(function () {
-    if (canUseDOM) {
-      const lastFocusedElementOutsideTrap = document.activeElement;
-      return function () {
-        if (lastFocusedElementOutsideTrap && document.contains(lastFocusedElementOutsideTrap)) {
-          UIManager.focus(lastFocusedElementOutsideTrap);
-        }
-      };
-    }
-  }, []);
+  // React.useEffect(function () {
+  //   if (canUseDOM) {
+  //     const lastFocusedElementOutsideTrap = document.activeElement;
+  //     return function () {
+  //       if (lastFocusedElementOutsideTrap && document.contains(lastFocusedElementOutsideTrap)) {
+  //         UIManager.focus(lastFocusedElementOutsideTrap);
+  //       }
+  //     };
+  //   }
+  // }, []);
 
   return (
     <>


### PR DESCRIPTION
### 작업내용
- [모달 닫혔을때 클릭한 엘리먼트로 포커스 주는 기능](https://github.com/necolas/react-native-web/issues/1822)이 들어가 있음.
- 이로 인해, 모달이 닫힌 후, 스크롤이 움직이는 현상 발생
- 해당 기능을 삭제함

### 관련 슬랙 쓰레드
- https://zigbang.slack.com/archives/C4NFLRMHS/p1627470344286300