### PR TITLE
CSS 파싱 에러 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.4",
+  "version": "0.17.2-zigbang.5-alpha1",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.5-alpha1",
+  "version": "0.17.2-zigbang.5",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.5-alpha1",
+  "version": "0.17.2-zigbang.5",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.4",
+  "version": "0.17.2-zigbang.5-alpha1",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -23,7 +23,7 @@ import i18nStyle from './i18nStyle';
 import { atomic, classic, inline, stringifyValueWithProperty } from './compile';
 import initialRules from './initialRules';
 import modality from './modality';
-import { STYLE_ELEMENT_ID, STYLE_GROUPS, STYLE_SHORT_FORM_EXPANSIONS } from './constants';
+import { STYLE_ELEMENT_ID, STYLE_GROUPS } from './constants';
 
 export default function createStyleResolver() {
   let inserted, sheet, cache;
@@ -153,7 +153,7 @@ export default function createStyleResolver() {
       return resolved[dir][key];
     }
 
-    const flatStyle = getLongFormProperties(flattenStyle(style));
+    const flatStyle = flattenStyle(style);
     const localizedStyle = createCompileableStyle(i18nStyle(flatStyle));
 
     // slower: convert style object to props and cache
@@ -252,41 +252,3 @@ const createCacheKey = (id) => {
 };
 
 const classListToString = (list) => list.join(' ').trim();
-
-const getLongFormProperties = function (style) {
-  if (!style) return {};
-
-  const resolvedStyle = {};
-  Object.keys(style)
-    .sort()
-    .forEach(function (key) {
-      const value = style[key];
-      switch (key) {
-        case 'flex': {
-          if (value === -1) {
-            resolvedStyle.flexGrow = 0;
-            resolvedStyle.flexShrink = 1;
-            resolvedStyle.flexBasis = 'auto';
-          } else {
-            resolvedStyle.flexGrow = value;
-            resolvedStyle.flexShrink = 1;
-            resolvedStyle.flexBasis = '0%';
-          }
-          break;
-        }
-        default: {
-          const longFormProperties = STYLE_SHORT_FORM_EXPANSIONS[key];
-          if (longFormProperties) {
-            longFormProperties.forEach(function (longForm, i) {
-              if (typeof style[longForm] === 'undefined') {
-                resolvedStyle[longForm] = value;
-              }
-            });
-          } else {
-            resolvedStyle[key] = value;
-          }
-        }
-      }
-    });
-  return resolvedStyle;
-};

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -164,7 +164,7 @@ export default function createStyleResolver() {
           const value = localizedStyle[styleProp];
           if (value != null) {
             const className = getClassName(styleProp, value);
-            if (className) {
+            if (className && key) {
               props.classList.push(className);
             } else {
               // Certain properties and values are not transformed by 'createReactDOMStyle' as they


### PR DESCRIPTION
기존에 [이 이슈](https://github.com/necolas/react-native-web/issues/2007) 를 해결하기 위해 처리했던 로직이 특정상황에 에러를 내는 경우가 있음.
- 커밋: https://github.com/zigbang/react-native-web/pull/2/commits/cdd74ff7f40063f148c81d89ad05710a33f974cf
- 위 코드가 style이 엘리먼트에 적용되는 시점에 스타일 속성들을 조작하는데, 
이로 인해 css를 생성해내는 시점과, style을 적용하는 시점에 파싱하는 style 속성이 달라져서 스타일이 틀어지는 현상 발생

### 해결
- 위 코드 롤백
- 빌드타이밍에 생성된 스타일이 아니면, className을 자동 부여하지 않도록 수정 - https://github.com/zigbang/react-native-web/commit/fffdcda25574ba9ed738bf8744eff3c344b9bf8f