### PR TITLE
style 성능 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.17.2-zigbang.6",
+  "version": "0.17.2-zigbang.7",
   "name": "monorepo",
   "scripts": {
     "clean": "del-cli ./packages/*/dist",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
 		"registry": "https://npm.zigbang.io/"
 	},
   "name": "react-native-web",
-  "version": "0.17.2-zigbang.6",
+  "version": "0.17.2-zigbang.7",
   "description": "Forked React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -155,6 +155,7 @@ export default function createStyleResolver() {
 
     const flatStyle = flattenStyle(style);
     const localizedStyle = createCompileableStyle(i18nStyle(flatStyle));
+    let isInlined = false;
 
     // slower: convert style object to props and cache
     const props = Object.keys(localizedStyle)
@@ -164,7 +165,7 @@ export default function createStyleResolver() {
           const value = localizedStyle[styleProp];
           if (value != null) {
             const className = getClassName(styleProp, value);
-            if (className && key) {
+            if (className && !isInlined) {
               props.classList.push(className);
             } else {
               // Certain properties and values are not transformed by 'createReactDOMStyle' as they
@@ -185,6 +186,7 @@ export default function createStyleResolver() {
                   });
                 });
               } else {
+                isInlined = true;
                 if (!props.style) {
                   props.style = {};
                 }


### PR DESCRIPTION
- 현재는 엘리먼트에 스타일 요소들이 바인딩 될때 요소중에 inline스타일이 하나라도 있으면 전체 요소가 inline으로 적용되고 있음.
- 스타일을 바인딩하기 위해 loop를 도는 로직에, inline 스타일을 만나기 전까진 캐시된 스타일을 사용하도록 수정
- 캐시된 스타일을 사용하는 케이스가 늘어나기 때문에 성능의 이점이 있을 것으로 기대됨